### PR TITLE
Fix undefined variable issue

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,7 +67,7 @@ class Plugin extends CraftPlugin
         /**
          * Setup user
          */
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function () {
+        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function () use ($app, $settings) {
             $user = $app->getUser()->getIdentity();
 
             Sentry\configureScope(function (Scope $scope) use ($settings, $user) {


### PR DESCRIPTION
Added `use ($app, $settings)` to the `Plugins::EVENT_AFTER_LOAD_PLUGINS` event.

Fixes https://github.com/born05/craft-sentry/issues/8#issuecomment-710138433