### PR TITLE
Added `getSentry` method

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -149,6 +149,14 @@ class Plugin extends CraftPlugin
         );
     }
 
+    /**
+     * @return SentryService
+     */
+    public function getSentry(): SentryService
+    {
+        return $this->sentry;
+    }
+
     private function getScriptOptions() {
         $options = [];
         


### PR DESCRIPTION
Allows us to use calls like `Sentry::$plugin->getSentry()->handleException($exception);` without IDEs complaining.