### PR TITLE
Feature/add sample rate

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -63,6 +63,7 @@ class Plugin extends CraftPlugin
             'dsn'         => $settings->clientDsn,
             'environment' => CRAFT_ENVIRONMENT,
             'release'     => $settings->release,
+            'traces_sample_rate' => $settings->sampleRate,
 
             // Prevent ExceptionListenerIntegration from loading.
             'integrations' => static function (array $integrations) {
@@ -165,7 +166,7 @@ class Plugin extends CraftPlugin
 
     private function getScriptOptions() {
         $options = [];
-        
+
         if (class_exists('\born05\contentsecuritypolicy\Plugin')) {
             $options['nonce'] = \born05\contentsecuritypolicy\Plugin::$plugin->headers->registerNonce('script-src');
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -137,7 +137,7 @@ class Plugin extends CraftPlugin
                       environment: '".CRAFT_ENVIRONMENT."',
                       debug: $isDevMode,
                       integrations: [new Sentry.Integrations.BrowserTracing()],
-                      tracesSampleRate: 1.0,
+                      tracesSampleRate: $settings->sampleRate,
                     });", View::POS_END, $this->getScriptOptions());
                 }
             );

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -12,6 +12,7 @@ class Settings extends Model
     public $excludedCodes = ['404'];
     public $release; // Release number/name used by sentry.
     public $reportJsErrors = false;
+    public $sampleRate = 1.0;
 
     public function rules()
     {
@@ -19,6 +20,7 @@ class Settings extends Model
             [['enabled', 'anonymous', 'reportJsErrors'], 'boolean'],
             [['clientDsn', 'excludedCodes', 'release'], 'string'],
             [['clientDsn'], 'required'],
+            [['sampleRate'], 'number'],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -20,7 +20,7 @@ class Settings extends Model
             [['enabled', 'anonymous', 'reportJsErrors'], 'boolean'],
             [['clientDsn', 'excludedCodes', 'release'], 'string'],
             [['clientDsn'], 'required'],
-            [['sampleRate'], 'number'],
+            [['sampleRate'], 'number', 'min' => 0, 'max' => 1],
         ];
     }
 }


### PR DESCRIPTION
Adds the ability to set the sample rate for both front & back end.

I recently installed this plugin on a site that gets a fair amount of traffic and it tore right through our transaction quota. This exposes a setting to make it easier to tweak that.

To edit your sample rate, just add `sampleRate` to your `sentry-sdk.php` config:

```php
return [
        'enabled' => true,
        'anonymous' => false,
        'clientDsn' => App::env('SENTRY_DSN') ?: '',
        'excludedCodes' => [],
        'release' => App::env('SENTRY_RELEASE') ?: null,
        'reportJsErrors' => true,
        'sampleRate' => 0.8
]
```