### PR TITLE
Use getenv() to get CRAFT_ENVIRONMENT

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,7 +61,7 @@ class Plugin extends CraftPlugin
          */
         $options = [
             'dsn'                => $settings->clientDsn,
-            'environment'        => CRAFT_ENVIRONMENT,
+            'environment'        => getenv('CRAFT_ENVIRONMENT'),
             'release'            => $settings->release,
             'traces_sample_rate' => $settings->sampleRate,
         ];


### PR DESCRIPTION
I'm getting this error on PHP 8, Craft 4, and `2.0.0-beta.1` of this plugin:

```
Exception 'Error' with message 'Undefined constant "born05\sentry\CRAFT_ENVIRONMENT"'

in /Users/reinhard/Work - Client/Sendbird/craft-cms/vendor/born05/craft-sentry/src/Plugin.php:64

Stack trace:
#0 /craft-cms/vendor/yiisoft/yii2/base/BaseObject.php(109): born05\sentry\Plugin->init()
#1 /craft-cms/vendor/yiisoft/yii2/base/Module.php(161): yii\base\BaseObject->__construct(Array)
#2 /craft-cms/vendor/craftcms/cms/src/base/Plugin.php(122): yii\base\Module->__construct('sentry-sdk', Object(craft\console\Application), Array)
...
```