### PR TITLE
use previous exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Craft Sentry Changelog
 
+## Unreleased
+### Changed
+- If the exception is a Twig Runtime exception, use the previous one instead.
+
 ## 2.0.0 - 2022-07-13
 ### Changed
 - Fixed craft 4 support

--- a/src/services/SentryService.php
+++ b/src/services/SentryService.php
@@ -8,6 +8,7 @@ use Craft;
 use craft\base\Component;
 
 use Sentry;
+use Twig\Error\RuntimeError as TwigRuntimeError;
 
 class SentryService extends Component
 {
@@ -15,6 +16,11 @@ class SentryService extends Component
     {
         $plugin = SentryPlugin::$plugin;
         $settings = $plugin->getSettings();
+
+        // If this is a Twig Runtime exception, use the previous one instead
+        if ($exception instanceof TwigRuntimeError && ($previousException = $exception->getPrevious()) !== null) {
+            $exception = $previousException;
+        }
 
         $statusCode = $exception->statusCode ?? null;
 


### PR DESCRIPTION
Twig captures now all exceptions within template rendering. So all `{% exit 404 %}` will be send to Sentry. This returns the previous behavior of the plugin in Craft 3. It's the same behavior Craft CMS do now.