### PR TITLE
Master

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -79,6 +79,10 @@ class Plugin extends CraftPlugin
             };
         }
 
+        if ($settings->sensitiveFields && is_array($settings->sensitiveFields)) {
+            $this->sentry->initDataScrubbing($settings->sensitiveFields, $options);
+        }
+
         Sentry\init($options);
 
         /**

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -15,6 +15,7 @@ class Settings extends Model
     public $sampleRate = 1.0; // Client only option
     public $performanceMonitoring = true; // Client only option
     public $autoSessionTracking = false; // Client only option
+    public $sensitiveFields; // Fields containing sensitive data in request
 
     public function rules()
     {

--- a/src/services/SentryService.php
+++ b/src/services/SentryService.php
@@ -34,4 +34,22 @@ class SentryService extends Component
 
         Sentry\captureException($exception);
     }
+
+    public function initDataScrubbing($sensitiveFields, &$options)
+    {
+        $options['before_send'] =  function (Sentry\Event $event) use ($sensitiveFields) {
+            $replaceValue = '[Filtered]';
+            $request = $event->getRequest();
+
+            if(isset($request['data'])) {
+                foreach ($sensitiveFields as $sensitiveField) {
+                    if(is_string($sensitiveField) && isset($request['data'][$sensitiveField])) {
+                        $request['data'][$sensitiveField] = $replaceValue;
+                    }
+                }
+            }
+            $event->setRequest($request);
+            return $event;
+        };
+    }
 }


### PR DESCRIPTION
Support filtering of sensitive request data with the following configuration (#28):

```
 'sensitiveFields' => [
        'firstname',
        'lastname',
        'email',
        'password',
    ],
```