### PR TITLE
Added ignoreErrors option for use with sentry js client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Craft Sentry Changelog
 
+## 3.1.0-beta.1 - 2024-06-10
+### Changed
+- Added ignoreErrors option for use with sentry js client
+
 ## 3.0.0-beta.1 - 2024-03-29
 ### Changed
 - Added craft 5 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Craft Sentry Changelog
 
+## 3.1.1-beta.1 - 2024-06-10
+### Changed
+- Corrected treatment of ignoreErrors option as an array
+
 ## 3.1.0-beta.1 - 2024-06-10
 ### Changed
 - Added ignoreErrors option for use with sentry js client

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ return [
         'release'        => getenv('SENTRY_RELEASE') ?: null, // Release number/name used by sentry.
         'reportJsErrors' => false,
         'sampleRate'     => 1.0,
+        'ignoreErrors'   => [
+          // Email link Microsoft Outlook crawler compatibility error
+          // cf. https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062
+          "Non-Error promise rejection captured with value: Object Not Found Matching Id:",
+        ]
     ],
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ return [
         'enabled'        => true,
         'anonymous'      => false, // Determines to log user info or not
         'clientDsn'      => getenv('SENTRY_DSN') ?: 'https://example@sentry.io/123456789', // Set as string or use environment variable.
+        'clientKey'      => getenv('SENTRY_CLIENT_KEY') ?: 'z987654321a', // https://js.sentry-cdn.com/z987654321a.min.js
         'excludedCodes'  => ['400', '404', '429'],
         'release'        => getenv('SENTRY_RELEASE') ?: null, // Release number/name used by sentry.
         'reportJsErrors' => false,

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "born05/craft-sentry",
     "description": "Pushes Craft CMS errors to Sentry.",
-    "version": "3.1.0-beta.1",
+    "version": "3.1.1-beta.1",
     "type": "craft-plugin",
     "keywords": [
         "craft",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "born05/craft-sentry",
     "description": "Pushes Craft CMS errors to Sentry.",
+    "version": "3.1.0-beta.1",
     "type": "craft-plugin",
     "keywords": [
         "craft",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,8 @@ class Plugin extends CraftPlugin
                         window.sentryOnLoad = function () {
                             Sentry.init({
                             release: '$settings->release',
-                            environment: '".App::env('CRAFT_ENVIRONMENT')."'
+                            environment: '".App::env('CRAFT_ENVIRONMENT')."',
+                            ignoreErrors: '$settings->ignoreErrors',
                             });
                         };", View::POS_END, $this->getScriptOptions());
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -124,6 +124,7 @@ class Plugin extends CraftPlugin
                     function (TemplateEvent $event) {
                         $settings = $this->getSettings();
                         $view = Craft::$app->getView();
+                        $ignoreErrors = json_encode($settings->ignoreErrors);
 
                         $view->registerScript("
                         // Configure sentryOnLoad before adding the Loader Script
@@ -131,7 +132,7 @@ class Plugin extends CraftPlugin
                             Sentry.init({
                             release: '$settings->release',
                             environment: '".App::env('CRAFT_ENVIRONMENT')."',
-                            ignoreErrors: '$settings->ignoreErrors',
+                            ignoreErrors: $ignoreErrors,
                             });
                         };", View::POS_END, $this->getScriptOptions());
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -14,6 +14,7 @@ class Settings extends Model
     public $release; // Release number/name used by sentry.
     public $reportJsErrors = false; // Client only option
     public $sampleRate = 1.0; // Client only option
+    public $ignoreErrors = [];
 
     /**
      * @inheritdoc
@@ -23,6 +24,7 @@ class Settings extends Model
         return [
             [['enabled', 'anonymous', 'reportJsErrors'], 'boolean'],
             [['clientDsn', 'clientKey', 'excludedCodes', 'release'], 'string'],
+            [['ignoreErrors'], 'array'],
             [['clientDsn'], 'required'],
             [['sampleRate'], 'number', 'min' => 0, 'max' => 1],
         ];


### PR DESCRIPTION
We add the `ignoreErrors` option for use with sentry js client.

This is needed as many sites are getting flooded with errors from the Microsoft Outlook SafeLinks crawler with a signature of `Non-Error promise rejection captured with value: Object Not Found Matching Id`.

See the discussion at:
https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062